### PR TITLE
add filter uptimesec

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -33,8 +33,16 @@ def uptime(boot_time):
     return retval
 
 
+def uptimesec(boot_time):
+    import time
+    upt = time.time() - boot_time
+
+    return round(upt)
+
+
 def register_filters(env):
     env.filters['KB'] = kb
     env.filters['MB'] = mb
     env.filters['GB'] = gb
     env.filters['uptime'] = uptime
+    env.filters['uptimesec'] = uptimesec


### PR DESCRIPTION
Add very simple filter `uptimesec` to publish up-time as number of seconds since boot time
Usefull to publish up-time to time series database such as InfluxDB (, prometheus, ...)
Suggested usage:
`{ "boot_time/{{x|uptimesec}}": "uptimesec" }`

Many thanks for your nice tool 👍 