### PR TITLE
Add system.d service file

### DIFF
--- a/psmqtt.service
+++ b/psmqtt.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Resource daemon to MQTT
+After=multi-user.target
+
+[Service]
+WorkingDirectory=/path/to/psmqtt
+User=nobody
+Type=idle
+ExecStart=/usr/bin/python3 /path/to/psmqtt/psmqtt.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add example system.d service file.

Simply amend file with correct path of installation dir.

$ cp psmqtt.service to /etc/system.d/system
$ sudo systemctl enable psmqtt.service
$ sudo systemctl start psmqtt.service