### PR TITLE
Update debian.md for venvs

### DIFF
--- a/doc/debian.md
+++ b/doc/debian.md
@@ -34,13 +34,37 @@ smartctl --scan
 /dev/nvme0 -d nvme # /dev/nvme0, NVMe device
 ```
 
-## Installation
+## Installation without using a venv
 
 ```
 git clone https://github.com/asokolsky/psmqtt.git
 git switch typing
 python3 -m pip install -r requirements.txt
 ```
+If you get an `error: externally-managed-environment` you'll have to decide if you want to keep using venvs, which is recommended by Python and Debian. If you don't want venvs you can skip the next paragraph and just run
+```
+rm /usr/lib/python3.11/EXTERNALLY-MANAGED
+```
+
+## Installation inside a venv
+
+
+Since Debian 12 (Bookworm) Python defaults to using venvs for modules installed with pip. They also strongly recommend keeping it as an "externally-managed-environment".
+
+As above, first clone the repository by running
+```
+git clone https://github.com/asokolsky/psmqtt.git
+```
+If you haven't already done so, you should create a directory for your venvs. Debian uses `~/.venvs` so I'll use that here.
+The following command creates a new folder and venv named psmqtt.
+```
+python3 -m venv ~/.venvs/psmqtt
+```
+Then install the required modules, replacing `~/.venvs` and `/path/to/psmqtt/` with your proper paths.
+```
+~/.venvs/psmqtt/bin/python3 -m pip install -r /path/to/psmqtt/requirements.txt
+```
+For the rest of the tutorial you'll need to replace every occurence of `python3` (comands and configs) with `~/.venvs/psmqtt/bin/python3`.
 
 ## First Run
 


### PR DESCRIPTION
Since Debian 12 (Bookworm) Python defaults to using venvs for modules installed with pip. Added instructions for installation with or without venvs.