### PR TITLE
Fix requirements.txt to use Paho 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 recurrent==0.4.1
-paho-mqtt==1.6.1
+paho-mqtt==2
 python-dateutil==2.8.2
 psutil==5.9.5
 jinja2==3.1.4


### PR DESCRIPTION
I've got the following error when running psmqtt in Docker:

```
Traceback (most recent call last):
  File "/tmp/psmqtt/psmqtt.py", line 154, in <module>
    run()
  File "/tmp/psmqtt/psmqtt.py", line 100, in run
    mqttc = MqttClient(
            ^^^^^^^^^^^
  File "/tmp/psmqtt/src/task.py", line 37, in __init__
    self.mqttc = paho.Client(paho.CallbackAPIVersion.VERSION1,
                             ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'paho.mqtt.client' has no attribute 'CallbackAPIVersion'
```
I found out that the code had been adapted for using Paho 2  (https://github.com/eschava/psmqtt/commit/837d8adbf15f2688b992d8729b64b8253476ac02) but the requirements file had not been updated. When I update paho the error disappears.
