### PR TITLE
Add basic integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest
+
+      - name: Build docker image for integration tests
+        run: docker build -t psmqtt:latest .
+
       - name: Run tests
         run: |
           pytest -vvvv --log-level=INFO -s -m integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11' 
+          python-version: '3.13' 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11' 
+          python-version: '3.13' 
       - name: Lint code with flake8
         run: |
           pip install flake8
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11' 
+          python-version: '3.13' 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -52,8 +52,24 @@ jobs:
           pip install pytest
       - name: Run tests
         run: |
-          pytest
+          pytest -vvv --log-level=INFO -m unit
       
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13' 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest -vvvv --log-level=INFO -s -m integration
+
   build_docker_dependabot:
     runs-on: ubuntu-latest
     # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
 
   build_docker_dependabot:
     runs-on: ubuntu-latest
+    needs: [test_dependencies,lint_code,unit_tests,integration_tests]
     # see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets
     # for the reason why DependaBot pull requests have no access to secrets like ${{ secrets.PAT_TOKEN_FOR_GITHUB }};
     # this lack of access forces us not to push images when dependabot runs
@@ -104,6 +105,7 @@ jobs:
 
   build_docker_nonroot_variant:
     runs-on: ubuntu-latest
+    needs: [test_dependencies,lint_code,unit_tests,integration_tests]
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
@@ -132,6 +134,7 @@ jobs:
 
   build_docker_root_variant:
     runs-on: ubuntu-latest
+    needs: [test_dependencies,lint_code,unit_tests,integration_tests]
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+docker:
+	docker build -t psmqtt:latest .
+
+# NOTE: during integration-tests the "testcontainers" project will be used to spin up 
+#       both a Mosquitto broker and the rpi2home-assistant docker, so make sure you don't
+#       have a Mosquitto broker (or other containers) already listening on the 1883 port
+#       when using this target:
+integration-test:
+ifeq ($(REGEX),)
+	pytest -vvvv --log-level=INFO -s -m integration
+else
+	pytest -vvvv --log-level=INFO -s -m integration -k $(REGEX)
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,28 @@
+# Basic development targets
+
+format:
+	black .
+
+lint:
+	ruff check src/
+	flake8 -v
 
 docker:
 	docker build -t psmqtt:latest .
 
-# NOTE: during integration-tests the "testcontainers" project will be used to spin up 
-#       both a Mosquitto broker and the rpi2home-assistant docker, so make sure you don't
-#       have a Mosquitto broker (or other containers) already listening on the 1883 port
-#       when using this target:
+test: unit-test integration-test
+
+unit-test:
+ifeq ($(REGEX),)
+	pytest -vvv --log-level=INFO -m unit
+else
+	pytest -vvvv --log-level=INFO -s -m unit -k $(REGEX)
+endif
+
+# During integration-tests the "testcontainers" project will be used to spin up 
+# both a Mosquitto broker and the PSMQTT docker, so make sure you don't
+# have a Mosquitto broker (or other containers) already listening on the 1883 port
+# when using this target:
 integration-test:
 ifeq ($(REGEX),)
 	pytest -vvvv --log-level=INFO -s -m integration

--- a/integration_tests/integration-tests-psmqtt.conf
+++ b/integration_tests/integration-tests-psmqtt.conf
@@ -6,13 +6,12 @@
 
 mqtt_broker = '__MQTT_BROKER_IP_PLACEHOLDER__'
 mqtt_port = __MQTT_BROKER_PORT_PLACEHOLDER__
-#mqtt_clientid = 'psmqtt-1'
+mqtt_clientid = 'psmqtt-integration-test-client'
 mqtt_username = ''
 mqtt_password = ''
 mqtt_clean_session = False
 mqtt_qos = 0
 mqtt_retain = False
-#c = 'psmqtt/' + socket.gethostname() + '/'
 mqtt_request_topic = 'request'
 
 schedule = {

--- a/integration_tests/integration-tests-psmqtt.conf
+++ b/integration_tests/integration-tests-psmqtt.conf
@@ -7,6 +7,7 @@
 mqtt_broker = '__MQTT_BROKER_IP_PLACEHOLDER__'
 mqtt_port = __MQTT_BROKER_PORT_PLACEHOLDER__
 mqtt_clientid = 'psmqtt-integration-test-client'
+#mqtt_topic_prefix = "integration-test"
 mqtt_username = ''
 mqtt_password = ''
 mqtt_clean_session = False

--- a/integration_tests/integration-tests-psmqtt.conf
+++ b/integration_tests/integration-tests-psmqtt.conf
@@ -1,0 +1,27 @@
+#
+# PSMQTT configuration file for INTEGRATION TESTS
+#
+
+#import socket
+
+mqtt_broker = '__MQTT_BROKER_IP_PLACEHOLDER__'
+mqtt_port = __MQTT_BROKER_PORT_PLACEHOLDER__
+#mqtt_clientid = 'psmqtt-1'
+mqtt_username = ''
+mqtt_password = ''
+mqtt_clean_session = False
+mqtt_qos = 0
+mqtt_retain = False
+#c = 'psmqtt/' + socket.gethostname() + '/'
+mqtt_request_topic = 'request'
+
+schedule = {
+    "every 1 seconds": [
+        "cpu_percent",
+        "virtual_memory/percent",
+    ],
+    "every 3 seconds": "disk_usage/percent/|",  # slash replaced with vertical slash
+    "every 5 seconds": {
+        "boot_time/{{x|uptime}}": "uptime",
+    }
+}

--- a/integration_tests/mosquitto_container.py
+++ b/integration_tests/mosquitto_container.py
@@ -1,0 +1,157 @@
+import os
+import time
+from testcontainers.mqtt import MosquittoContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+from typing_extensions import Self
+
+from paho.mqtt import client as mqtt_client
+import paho.mqtt.enums
+from queue import Queue
+from typing import Optional
+
+# ---------------------------------------------------------------------------- #
+#                          MosquittoContainerEnhanced                          #
+# ---------------------------------------------------------------------------- #
+
+class MosquittoContainerEnhanced(MosquittoContainer):
+    """
+    Specialization of MosquittoContainer adding the ability to watch topics
+    """
+
+    def __init__(
+        self,
+        image: str = "eclipse-mosquitto:latest",
+        **kwargs,
+    ) -> None:
+        super().__init__(image, **kwargs)
+
+        # helper used to turn asynchronous methods into synchronous:
+        self.msg_queue = Queue()
+
+        # dictionary of watched topics and their message counts:
+        self.watched_topics = {}
+
+    def start(self) -> Self:
+        # do container start
+        super().start()
+        # now add callback
+        self.get_client().on_message = MosquittoContainerEnhanced.on_message
+        return self
+
+    def stop(self, force=True, delete_volume=True) -> None:
+        self.watched_topics = {}  # clean all watched topics as well
+        super().stop(force, delete_volume)
+
+    class WatchedTopicInfo:
+        def __init__(self):
+            self.count = 0
+            self.timestamp_start_watch = time.time()
+            self.last_payload = ""
+
+        def on_message(self, msg: mqtt_client.MQTTMessage):
+            self.count += 1
+            # for simplicity: assume strings are used in integration tests and are UTF8-encoded:
+            self.last_payload = msg.payload.decode("UTF-8")
+
+        def get_message_count(self) -> int:
+            return self.count
+
+        def get_last_payload(self) -> str:
+            return self.last_payload
+
+        def get_rate(self) -> float:
+            duration = time.time() - self.timestamp_start_watch
+            if duration > 0:
+                return float(self.count) / float(duration)
+            return 0.0
+
+    def on_message(
+        client: mqtt_client.Client, mosquitto_container: "MosquittoContainerEnhanced", msg: mqtt_client.MQTTMessage
+    ):
+        # very verbose but useful for debug:
+        # print(f"Received `{msg.payload.decode()}` from `{msg.topic}` topic")
+        if msg.topic == "$SYS/broker/messages/received":
+            mosquitto_container.msg_queue.put(msg)
+        else:
+            # this should be a topic added through the watch_topics() API...
+            # just check it has not been removed (e.g. by unwatch_all):
+            if msg.topic in mosquitto_container.watched_topics:
+                mosquitto_container.watched_topics[msg.topic].on_message(msg)
+            else:
+                print(f"Received msg on topic [{msg.topic}] that is not being watched")
+
+    def get_messages_received(self) -> int:
+        """
+        Returns the total number of messages received by the broker so far.
+        """
+
+        try:
+            client = self.get_client()
+        except OSError as err:
+            raise RuntimeError(f"Could not connect to Mosquitto broker: {err}")
+
+        client.subscribe("$SYS/broker/messages/received")
+
+        # wait till we get the first message from the topic;
+        # this wait will be up to 'sys_interval' second long (see mosquitto.conf)
+        try:
+            message = self.msg_queue.get(block=True, timeout=5)
+            return int(message.payload.decode())
+        except Queue.Empty:
+            return 0
+
+    def watch_topics(self, topics: list):
+        try:
+            client = self.get_client()
+        except OSError as err:
+            raise RuntimeError(f"Could not connect to Mosquitto broker: {err}")
+
+        filtered_topics = []
+        for t in topics:
+            if t in self.watched_topics:
+                continue  # nothing to do... the topic had already been subscribed
+            self.watched_topics[t] = MosquittoContainerEnhanced.WatchedTopicInfo()
+            # the topic list is actually a list of tuples (topic_name,qos)
+            filtered_topics.append((t, 0))
+
+        # after subscribe() the on_message() callback will be invoked
+        err, _ = client.subscribe(filtered_topics)
+        if err != paho.mqtt.enums.MQTTErrorCode.MQTT_ERR_SUCCESS:
+            raise RuntimeError(f"Failed to subscribe to topics: {filtered_topics}")
+
+    def unwatch_all(self):
+        try:
+            client = self.get_client()
+        except OSError as err:
+            raise RuntimeError(f"Could not connect to Mosquitto broker: {err}")
+
+        # unsubscribe from all topics
+        client.unsubscribe(list(self.watched_topics.keys()))
+        self.watched_topics = {}
+
+    def get_messages_received_in_watched_topic(self, topic: str) -> int:
+        if topic not in self.watched_topics:
+            raise RuntimeError(f"Topic {topic} is not watched! Fix the test")
+        return self.watched_topics[topic].get_message_count()
+
+    def get_last_payload_received_in_watched_topic(self, topic: str) -> str:
+        if topic not in self.watched_topics:
+            raise RuntimeError(f"Topic {topic} is not watched! Fix the test")
+        return self.watched_topics[topic].get_last_payload()
+
+    def get_message_rate_in_watched_topic(self, topic: str) -> float:
+        if topic not in self.watched_topics:
+            raise RuntimeError(f"Topic {topic} is not watched! Fix the test")
+        return self.watched_topics[topic].get_rate()
+
+    def publish_message(self, topic: str, payload: str):
+        ret = self.client.publish(topic, payload)
+        ret.wait_for_publish(timeout=2)
+        if not ret.is_published():
+            raise RuntimeError(f"Could not publish a message on topic {topic} to Mosquitto broker: {ret}")
+
+    def print_logs(self) -> str:
+        print("** BROKER LOGS [STDOUT]:")
+        print(self.get_logs()[0].decode())
+        print("** BROKER LOGS [STDERR]:")
+        print(self.get_logs()[1].decode())

--- a/integration_tests/mosquitto_container.py
+++ b/integration_tests/mosquitto_container.py
@@ -1,13 +1,13 @@
-import os
+# Copyright (c) 2016 psmqtt project
+# Licensed under the MIT License.  See LICENSE file in the project root for full license information.
+
 import time
 from testcontainers.mqtt import MosquittoContainer
-from testcontainers.core.waiting_utils import wait_container_is_ready
 from typing_extensions import Self
 
 from paho.mqtt import client as mqtt_client
 import paho.mqtt.enums
 from queue import Queue
-from typing import Optional
 
 # ---------------------------------------------------------------------------- #
 #                          MosquittoContainerEnhanced                          #

--- a/integration_tests/psmqtt_container.py
+++ b/integration_tests/psmqtt_container.py
@@ -53,6 +53,10 @@ class PSMQTTContainer(DockerContainer):
         status = self.get_wrapped_container().status  # same as above
         return status == "running"
 
+    def get_short_id(self):
+        # the docker container ID is a long string, the "short ID" is just the first 12 characters
+        return self.get_wrapped_container().id[:12]
+
     def print_logs(self) -> str:
         print("** psmqtt LOGS [STDOUT]:")
         print(self.get_logs()[0].decode())

--- a/integration_tests/psmqtt_container.py
+++ b/integration_tests/psmqtt_container.py
@@ -4,7 +4,6 @@
 import os
 import shutil
 import tempfile
-import time
 from testcontainers.core.container import DockerContainer
 from testcontainers.mqtt import MosquittoContainer
 

--- a/integration_tests/test_integration_publish.py
+++ b/integration_tests/test_integration_publish.py
@@ -1,0 +1,79 @@
+import pytest
+import time
+import signal
+
+from integration_tests.psmqtt_container import PSMQTTContainer
+from integration_tests.mosquitto_container import MosquittoContainerEnhanced
+
+
+# GLOBALs
+
+broker = MosquittoContainerEnhanced()
+
+# HELPERS
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(request):
+    """
+    Fixture to setup and teardown the MQTT broker
+    """
+    broker.start()
+    print("Broker successfully started")
+
+    def remove_container():
+        broker.stop()
+
+    request.addfinalizer(remove_container)
+
+
+# TESTS
+
+@pytest.mark.integration
+def test_basic_publish():
+
+    with PSMQTTContainer(broker=broker) as container:
+
+        dockerid = container.get_short_id()
+        topics_under_test = [
+            {"topic_name": f"psmqtt/{dockerid}/cpu_percent", "expected_payload": "FLOATING_POINT_NUMBER", "min_msg_count": 5},
+            {"topic_name": f"psmqtt/{dockerid}/virtual_memory/percent", "expected_payload": "FLOATING_POINT_NUMBER", "min_msg_count": 5},
+            # disk_usage gets published every 3sec:
+            {"topic_name": f"psmqtt/{dockerid}/disk_usage/percent/|", "expected_payload": "FLOATING_POINT_NUMBER", "min_msg_count": 2},
+            # uptime gets published every 5sec:
+            {"topic_name": f"psmqtt/{dockerid}/uptime", "expected_payload": "STRING", "min_msg_count": 1},
+        ]
+
+        time.sleep(1)  # give time to the PSMQTTContainer to fully start
+        if not container.is_running():
+            print("Container under test has stopped running... test failed.")
+            container.print_logs()
+            assert False
+
+        broker.watch_topics([t["topic_name"] for t in topics_under_test])
+
+        # the integration test config contains a configuration to print the boot_time every 5sec,
+        # so wait a bit more to reduce test flakyness:
+        time.sleep(6)
+        container.print_logs()
+
+        for t in topics_under_test:
+            tname = t["topic_name"]
+            msg_count = broker.get_messages_received_in_watched_topic(tname)
+            last_payload = broker.get_last_payload_received_in_watched_topic(tname)
+            print(f"** TEST RESULTS for topic [{tname}]")
+            print(f"  Total messages in topic: {msg_count} msgs")
+            print(f"  Last payload in topic: {last_payload}")
+            
+            # some tolerance to deal with jitter during the test:
+            assert msg_count >= t["min_msg_count"] and msg_count <= t["min_msg_count"]+2
+            
+            # check payload
+            if t["expected_payload"] == "FLOATING_POINT_NUMBER":
+                assert isinstance(float(last_payload), float)
+            # no validation otherwise
+
+            print("\n")
+
+        broker.unwatch_all()
+        print("Integration test passed!")

--- a/integration_tests/test_integration_publish.py
+++ b/integration_tests/test_integration_publish.py
@@ -1,6 +1,5 @@
 import pytest
 import time
-import signal
 
 from integration_tests.psmqtt_container import PSMQTTContainer
 from integration_tests.mosquitto_container import MosquittoContainerEnhanced
@@ -64,10 +63,10 @@ def test_basic_publish():
             print(f"** TEST RESULTS for topic [{tname}]")
             print(f"  Total messages in topic: {msg_count} msgs")
             print(f"  Last payload in topic: {last_payload}")
-            
+
             # some tolerance to deal with jitter during the test:
             assert msg_count >= t["min_msg_count"] and msg_count <= t["min_msg_count"]+2
-            
+
             # check payload
             if t["expected_payload"] == "FLOATING_POINT_NUMBER":
                 assert isinstance(float(last_payload), float)

--- a/integration_tests/test_integration_reconn.py
+++ b/integration_tests/test_integration_reconn.py
@@ -5,13 +5,13 @@ import pytest
 import time
 
 from integration_tests.psmqtt_container import PSMQTTContainer
-from testcontainers.mqtt import MosquittoContainer
+from integration_tests.mosquitto_container import MosquittoContainerEnhanced
 
 
 @pytest.mark.integration
 def test_mqtt_reconnection():
 
-    broker = MosquittoContainer()
+    broker = MosquittoContainerEnhanced()
     broker.start()
     with PSMQTTContainer(broker) as container:
         time.sleep(1)  # give time to the PSMQTTContainer to fully start

--- a/integration_tests/test_integration_reconn.py
+++ b/integration_tests/test_integration_reconn.py
@@ -1,7 +1,8 @@
+# Copyright (c) 2016 psmqtt project
+# Licensed under the MIT License.  See LICENSE file in the project root for full license information.
+
 import pytest
 import time
-
-# from testcontainers.core.utils import raise_for_deprecated_parameter
 
 from integration_tests.psmqtt_container import PSMQTTContainer
 from testcontainers.mqtt import MosquittoContainer
@@ -29,7 +30,6 @@ def test_mqtt_reconnection():
                 container.print_logs()
                 assert False
 
-            # NOTE: MQTT_DEFAULT_RECONNECTION_PERIOD_SEC is equal 1sec
             for idx in range(1, 3):
                 time.sleep(1.5)
                 if not container.is_running():
@@ -47,9 +47,6 @@ def test_mqtt_reconnection():
                 print(e)
                 assert False
 
-            #topics_under_test = ["rpi2home-assistant/opto_input_1"]
-            #broker.watch_topics(topics_under_test)
-
             for idx in range(1, 3):
                 time.sleep(1.5)
                 if not container.is_running():
@@ -59,10 +56,6 @@ def test_mqtt_reconnection():
                     container.print_logs()
                     assert False
 
-            # now verify that there is also traffic on the topics:
-            # time.sleep(4)
-            #msg_rate = broker.get_message_rate_in_watched_topic(topics_under_test[0])
-            #assert msg_rate > 0
             print("Looks like PSMQTT container is still up and running... proceeding")
 
         print("Test passed. Container logs should indicate several attempts to reconnect:")

--- a/integration_tests/test_integration_reconn.py
+++ b/integration_tests/test_integration_reconn.py
@@ -1,0 +1,71 @@
+import pytest
+import time
+
+# from testcontainers.core.utils import raise_for_deprecated_parameter
+
+from integration_tests.psmqtt_container import PSMQTTContainer
+from testcontainers.mqtt import MosquittoContainer
+
+
+@pytest.mark.integration
+def test_mqtt_reconnection():
+
+    broker = MosquittoContainer()
+    broker.start()
+    with PSMQTTContainer(broker) as container:
+        time.sleep(1)  # give time to the PSMQTTContainer to fully start
+        if not container.is_running():
+            print("Container under test has stopped running while broker was still running?? test failed.")
+            container.print_logs()
+            assert False
+
+        for attempt in range(1, 3):
+            # BAM! stop the broker to simulate either a maintainance window or a power fault in the system where MQTT broker runs
+            print(f"Attempt #{attempt}: Simulating BROKER failure stopping the broker container...")
+            broker.stop()
+            time.sleep(0.5)
+            if not container.is_running():
+                print("Container under test has stopped running immediately after stopping the broker... test failed.")
+                container.print_logs()
+                assert False
+
+            # NOTE: MQTT_DEFAULT_RECONNECTION_PERIOD_SEC is equal 1sec
+            for idx in range(1, 3):
+                time.sleep(1.5)
+                if not container.is_running():
+                    print(
+                        "Container under test has stopped running probably after retrying the connection to the broker... test failed."
+                    )
+                    container.print_logs()
+                    assert False
+
+            # ok seems the container is still up -- that's good -- now let's see if it can reconnect
+            print(f"Attempt #{attempt}: About to restart the broker...")
+            try:
+                broker.start()
+            except Exception as e:
+                print(e)
+                assert False
+
+            #topics_under_test = ["rpi2home-assistant/opto_input_1"]
+            #broker.watch_topics(topics_under_test)
+
+            for idx in range(1, 3):
+                time.sleep(1.5)
+                if not container.is_running():
+                    print(
+                        "Container under test has stopped running probably after retrying the connection to the broker... test failed."
+                    )
+                    container.print_logs()
+                    assert False
+
+            # now verify that there is also traffic on the topics:
+            # time.sleep(4)
+            #msg_rate = broker.get_message_rate_in_watched_topic(topics_under_test[0])
+            #assert msg_rate > 0
+            print("Looks like PSMQTT container is still up and running... proceeding")
+
+        print("Test passed. Container logs should indicate several attempts to reconnect:")
+        container.print_logs()
+
+    broker.stop()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+# content of pytest.ini
+[pytest]
+markers =
+    unit: unit test
+    integration: integration tests using test containers

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ jinja2==3.1.5
 types-paho-mqtt==1.6.0.20240321
 # pySMART>=1.3.1.dev8 is required, see https://github.com/truenas/py-SMART/issues/86
 pySMART==1.4.1
+# testcontainers introduced MosquittoContainer in 4.6.0
+testcontainers>=4.6.0

--- a/src/formatter_test.py
+++ b/src/formatter_test.py
@@ -1,7 +1,9 @@
 import unittest
+import pytest
 
 from .formatter import Formatter
 
+@pytest.mark.unit
 class TestFormatter(unittest.TestCase):
 
     def test_get_format(self) -> None:
@@ -39,7 +41,3 @@ class TestFormatter(unittest.TestCase):
         self.assertEqual("2 days, 1:40", Formatter.format("{{x|uptime}}", n - 49*60*60 - 40*60))
         self.assertEqual("2 days, 1:39", Formatter.format("{{x|uptime}}", n - 49*60*60 - 40*60+30))
         self.assertEqual("2 days, 1:40", Formatter.format("{{x|uptime}}", n - 49*60*60 - 40*60-30))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/src/handlers_test.py
+++ b/src/handlers_test.py
@@ -382,4 +382,3 @@ class TestHandlers(unittest.TestCase):
             pass
 
         return
-

--- a/src/handlers_test.py
+++ b/src/handlers_test.py
@@ -3,6 +3,7 @@ import collections
 from collections import namedtuple
 from typing import Any, Dict, NamedTuple, Optional
 import psutil._common
+import pytest
 
 from .handlers import (
     DiskUsageCommandHandler,
@@ -20,6 +21,7 @@ from .handlers import (
     get_value
 )
 
+@pytest.mark.unit
 class TestHandlers(unittest.TestCase):
 
     def test_value_command_handler(self) -> None:
@@ -381,6 +383,3 @@ class TestHandlers(unittest.TestCase):
 
         return
 
-
-if __name__ == '__main__':
-    unittest.main()

--- a/src/topic_test.py
+++ b/src/topic_test.py
@@ -35,4 +35,3 @@ class TopicTest(unittest.TestCase):
         self.assertEqual("/*;/a", get_subtopic('/*;/**', 'a'))
         self.assertEqual("/*;/*;", get_subtopic('/*;/*;', 'a'))
         self.assertEqual("/*;/**;", get_subtopic('/*;/**;', 'a'))
-

--- a/src/topic_test.py
+++ b/src/topic_test.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from .topic import Topic
 
@@ -6,7 +7,7 @@ def get_subtopic(topic:str, param:str) -> str:
     t = Topic(topic)
     return t.get_subtopic(param) if t.is_multitopic() else topic
 
-
+@pytest.mark.unit
 class TopicTest(unittest.TestCase):
 
     def test_get_subtopic(self) -> None:
@@ -35,6 +36,3 @@ class TopicTest(unittest.TestCase):
         self.assertEqual("/*;/*;", get_subtopic('/*;/*;', 'a'))
         self.assertEqual("/*;/**;", get_subtopic('/*;/**;', 'a'))
 
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
This PR is adding some basic integration tests to psmqtt to validate the overall behavior against a real MQTT broker (Mosquitto broker). The integration tests adopt "testcontainers" as framework to ease interaction with dockers