### PR TITLE
improve SMART handler

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -242,10 +242,18 @@ Here follows the reference documentation for all required tasks and their parame
       Note that you cannot use a wildcard as `<param2>` together with a wildcard on `<param1>`.
   * Task name: `smart`
     * Short description: Self-Monitoring, Analysis and Reporting Technology System (SMART) counters built into most modern ATA/SATA, SCSI/SAS and NVMe disks. [ Full reference ]( https://www.smartmontools.org/wiki/TocDoc )
-    * **REQUIRED**: `<param1>`: The wildcard `*`  or `+` to select all disks or a the name of  a specific drive e.g. `/dev/md0` or `/dev/sda1`.
+    * **REQUIRED**: `<param1>`: The name of a specific drive e.g. `/dev/md0` or `/dev/sda`.
     * **REQUIRED**: `<param2>`: The wildcard `*` or `+` to select all S.M.A.R.T. attributes or a field name like 
-      `interface`, `is_ssd`, `model`, `name`, `path`, `rotation_rate`, `serial`, `smart_capable`, `smart_enabled`, `smart_status`, `temperature`, etc.
-      Try the following Python snippet on your prompt to see which SMART attributes are detected by pySMART library: `sudo python3 -c 'import pySMART; pySMART.Device("/dev/sda").all_attributes()'`
+      `interface`, `is_ssd`, `model`, `name`, `path`, `rotation_rate`, `serial`, `smart_capable`, `smart_enabled`, `smart_status`, `temperature`, `test_capabilities`.
+      All SMART attributes are reported in fields named `attribute_raw[ATTRIBUTE_NAME]`. The availability of specific
+      attributes depends on the disk vendor and disk model. E.g. a typical SMART attribute name would be `Power_On_Hours`
+      which can be selected using for `<param2>` the value `attribute_raw[Power_On_Hours]`.
+      All SMART tests (short self tests, long self tests, etc) are reported in fields named `test[TEST_INDEX]`
+      with `<TEST_INDEX>` being a number `0`, `1`, `2`, etc (depending on how many SMART tests were run on the disk).
+      The value of each `test[TEST_INDEX]` is a JSON string containing details about that test, e.g. `hours`, `type`,
+      `status`, etc. The tests are sorted by `hours` in decreasing order so that `test[0]` always indicates the most
+      recent SMART test results.
+      You can try the following Python snippet on your prompt to see which SMART attributes are detected by pySMART library for e.g. your device `/dev/sda`: `sudo python3 -c 'import pySMART; pySMART.Device("/dev/sda").all_attributes()'`
 
 #### <a name='CategoryNetwork'></a>Category Network
 

--- a/src/handlers_pysmart.py
+++ b/src/handlers_pysmart.py
@@ -46,7 +46,7 @@ class SmartCommandHandler(BaseHandler):
         val = info.get(param, None)
         if val is not None:
             return val
-        raise Exception(f"{self.name}: Parameter '{param}' is not supported")
+        raise Exception(f"{self.name}: Parameter '{param}' is not supported for device '{dev}")
 
     def get_value(self, dev: str) -> Payload:
         '''
@@ -71,7 +71,12 @@ class SmartCommandHandler(BaseHandler):
 
         # explode the "tests" entry to dictionary keys in the form
         #  tests[TEST_NUM]=JSON
-        sorted_test_list = sorted(smart_data.tests, key=lambda x: x.hours)
+        # sort the tests in such a way that test[0] is always the most recent one (having the highest "hours" value)
+        try:
+            sorted_test_list = sorted(smart_data.tests, key=lambda x: int(x.hours))
+        except ValueError:
+            # failed casting to int... use the pySMART sorting
+            sorted_test_list = smart_data.tests
         idx = 0
         for t in sorted_test_list:
             info[f"test[{idx}]"] = string_from_dict(t.__getstate__())

--- a/src/handlers_pysmart.py
+++ b/src/handlers_pysmart.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2016 psmqtt project
 # Licensed under the MIT License.  See LICENSE file in the project root for full license information.
 
-import logging
 from pySMART import Device as SmartDevice
 from typing import (
     List,
 )
 
 from .handlers_base import BaseHandler, Payload
-from .utils import string_from_dict_optionally
+from .utils import string_from_dict_optionally, string_from_dict
 
 class SmartCommandHandler(BaseHandler):
     '''
@@ -16,15 +15,14 @@ class SmartCommandHandler(BaseHandler):
     '''
 
     def __init__(self) -> None:
-        '''
-
-        '''
         super().__init__('smart')
         return
 
     def handle(self, params: List[str]) -> Payload:
         '''
-        Will call self.get_value()
+        Takes 2 parameters:
+        * device name
+        * parameter name or wildcard
         '''
         assert isinstance(params, list)
         if len(params) != 1 and len(params) != 2:
@@ -32,30 +30,56 @@ class SmartCommandHandler(BaseHandler):
 
         dev = params[0]
         param = params[1] if len(params) == 2 else ''
-        self.name = dev
-        self.device = SmartDevice(self.name)
 
-        if self.device.serial is None:
-            errmsg = f"{self.name}: Failed to read SMART data: probably root permissions are required"
-            logging.error(errmsg)
-            raise Exception(errmsg)
+        #if BaseHandler.is_wildcard(dev) and BaseHandler.is_wildcard(param):
+        #    raise Exception(f"{self.name}: Cannot list all SMART fields from all disks into the same task")
 
-        info = self.device.__getstate__()
-
-        # delete 2 fields that are actually very cluttered fields repeating all the other dictionary keys:
-        del info["attributes"]
-        del info["if_attributes"]
+        info = self.get_value(dev)
+        #logging.debug(f"{info}")
 
         if param == '':
             return string_from_dict_optionally(info, True)
-        elif BaseHandler.is_regular_wildcard(param):
-            return string_from_dict_optionally(info, False)
         elif BaseHandler.is_join_wildcard(param):
             return string_from_dict_optionally(info, True)
+        elif BaseHandler.is_regular_wildcard(param):
+            return string_from_dict_optionally(info, False)
         val = info.get(param, None)
         if val is not None:
             return val
         raise Exception(f"{self.name}: Parameter '{param}' is not supported")
 
-    def get_value(self) -> Payload:
-        raise Exception("Not implemented")
+    def get_value(self, dev: str) -> Payload:
+        '''
+        Uses methods of pySMART to acquire SMART counters
+        '''
+        smart_data = SmartDevice(dev)
+        if smart_data.serial is None:
+            raise Exception(f"{self.name}: Failed to read SMART data for device '{dev}': probably root permissions are required")
+
+        # __getstate__() is a non-documented magic function returning some _selected_
+        # fields of the SmartDevice class into a dictionary, which is easier to index in psmqtt
+        info = smart_data.__getstate__()
+
+        # explode the "attributes" entry to dictionary keys in the form
+        #  attribute_raw[ATTRIBUTE_NAME]=RAW_VALUE
+        for a in info["attributes"]:
+            if a is not None:
+                assert isinstance(a, dict)
+                assert "name" in a
+                assert "raw" in a
+                info[f"attribute_raw[{a['name']}]"] = a["raw"]
+
+        # explode the "tests" entry to dictionary keys in the form
+        #  tests[TEST_NUM]=JSON
+        sorted_test_list = sorted(smart_data.tests, key=lambda x: x.hours)
+        idx = 0
+        for t in sorted_test_list:
+            info[f"test[{idx}]"] = string_from_dict(t.__getstate__())
+            idx += 1
+
+        # delete 2 fields that are useless after the "explosion" just done:
+        del info["attributes"]
+        del info["if_attributes"]
+        del info["tests"]
+
+        return info

--- a/src/handlers_pysmart.py
+++ b/src/handlers_pysmart.py
@@ -73,7 +73,7 @@ class SmartCommandHandler(BaseHandler):
         #  tests[TEST_NUM]=JSON
         # sort the tests in such a way that test[0] is always the most recent one (having the highest "hours" value)
         try:
-            sorted_test_list = sorted(smart_data.tests, key=lambda x: int(x.hours))
+            sorted_test_list = sorted(smart_data.tests, key=lambda x: int(x.hours), reverse=True)
         except ValueError:
             # failed casting to int... use the pySMART sorting
             sorted_test_list = smart_data.tests
@@ -82,7 +82,7 @@ class SmartCommandHandler(BaseHandler):
             info[f"test[{idx}]"] = string_from_dict(t.__getstate__())
             idx += 1
 
-        # delete 2 fields that are useless after the "explosion" just done:
+        # delete fields that are useless after the flattening of SMART attributes and SMART tests just done:
         del info["attributes"]
         del info["if_attributes"]
         del info["tests"]

--- a/src/task.py
+++ b/src/task.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Any, List
 
+from .handlers_base import BaseHandler
 from .handlers_all import TaskHandlers
 from .topic import Topic
 from .mqtt_client import MqttClient
@@ -49,7 +50,10 @@ class Task:
         escapedParams = []
         for x in nonEmptyParams:
             if isinstance(x,str):
-                escapedParams.append(x.replace('/', '|'))
+                if BaseHandler.is_join_wildcard(x):
+                    continue
+                else:
+                    escapedParams.append(x.replace('/', '|'))
             elif isinstance(x,int):
                 escapedParams.append(str(x))
         if len(escapedParams) > 0:

--- a/src/task.py
+++ b/src/task.py
@@ -51,6 +51,8 @@ class Task:
         for x in nonEmptyParams:
             if isinstance(x,str):
                 if BaseHandler.is_join_wildcard(x):
+                    # skip any join wildcard (+) parameter from the MQTT topic; do insert however the regular wildcard (*)
+                    # so that the Topic class knows that it's actually a multi-topic
                     continue
                 else:
                     escapedParams.append(x.replace('/', '|'))


### PR DESCRIPTION
improve the "smart" task handler:
* make it easy to publish SMART attributes to MQTT
* make it easy to publish results of SMART tests to MQTT
* make the JSON representation of SMART data (when using the join wildcard +) more compact and understandable
* document the syntax for the new keys (attributes and tests) 

* fix MQTT default topic creation when join wildcards (+) are used 