### PR TITLE
Add docs about PSMQTT status topic

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -19,6 +19,7 @@
 	* [MQTT Topic](#mqtt-topic)
 	* [HomeAssistant Discovery Messages](#homeassistant-discovery-messages)
 * [Sending MQTT requests](#sending-mqtt-requests)
+* [Monitoring PSMQTT](#monitoring-psmqtt)
 * [Example configs](#example-configs)
 
 <!-- vscode-markdown-toc-config
@@ -587,6 +588,26 @@ E.g. to force psmqtt to run the task:
 it's possible to send the YAML string above on the topic **psmqtt/COMPUTER_NAME/request**;
 the task will be executed immediately when received and will be interpreted like any
 other task in the configuration file.
+
+
+## <a name='MonitoringPSMQTT'></a>Monitoring PSMQTT
+
+PSMQTT provides some observability feature about itself in 2 forms:
+* logs: each disconnection from MQTT broker, network issue or any failure in executing a configured task is obviously reported in the logs;
+* in the **psmqtt/COMPUTER_NAME/psmqtt_status** topic, where 3 metrics are published: `num_tasks_errors`, `num_tasks_success` and `num_mqtt_disconnects`; this feature is enabled by the configuration key `report_status_period_sec`:
+
+```
+logging:
+  report_status_period_sec: 10
+```
+
+Of course another way to monitor whether PSMQTT is working correctly is to check whether the output MQTT topics
+are updated on the expected frequency.
+
+If the HomeAssistant integration MQTT discovery messages are used, also note that PSMQTT will automatically configure
+the `expire_after` property of the sensors; that means that in case PSMQTT stops updating the sensor main topic for
+a time longer than the expected frequency, then the sensor’s state becomes `unavailable`. This offers another way
+to monitor whether PSMQTT is working as intended from HomeAssistant.
 
 
 ## <a name='Exampleconfigs'></a>Example configs

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -609,7 +609,10 @@ the `expire_after` property of the sensors; that means that in case PSMQTT stops
 a time longer than the expected frequency, then the sensor’s state becomes `unavailable`. This offers another way
 to monitor whether PSMQTT is working as intended from HomeAssistant.
 
-Finally, PSMQTT is also configuring the [MQTT Last Will](https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/) message on the (fixed) topic **psmqtt/COMPUTER_NAME/psmqtt_status**
+Finally, PSMQTT is also configuring the [MQTT Last Will](https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/) message on the (fixed) topic **psmqtt/COMPUTER_NAME/psmqtt_status**.
+Whenever PSMQTT goes online the payload `online` is published on that topic, with a retained message.
+Whenever PSMQTT goes offline the payload `offline` is published on that topic, with a retained message.
+This allows any other MQTT client to always immediately retrieve the actual status of a PSMQTT client: online/connected or offline/disconnected.
 
 ## <a name='Exampleconfigs'></a>Example configs
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -609,6 +609,7 @@ the `expire_after` property of the sensors; that means that in case PSMQTT stops
 a time longer than the expected frequency, then the sensor’s state becomes `unavailable`. This offers another way
 to monitor whether PSMQTT is working as intended from HomeAssistant.
 
+Finally, PSMQTT is also configuring the [MQTT Last Will](https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/) message on the (fixed) topic **psmqtt/COMPUTER_NAME/psmqtt_status**
 
 ## <a name='Exampleconfigs'></a>Example configs
 

--- a/psmqtt.py
+++ b/psmqtt.py
@@ -121,7 +121,7 @@ class PsmqttApp:
         new_status = (Task.num_errors, Task.num_success, MqttClient.num_disconnects)
         if new_status != app.last_logged_status:
             # publish status on MQTT
-            status_topic = app.status_topic
+            status_topic = app.mqtt_client.get_psmqtt_status_topic()
             app.mqtt_client.publish(status_topic + "/num_tasks_errors", Task.num_errors)
             app.mqtt_client.publish(status_topic + "/num_tasks_success", Task.num_success)
             app.mqtt_client.publish(status_topic + "/num_mqtt_disconnects", MqttClient.num_disconnects)
@@ -298,9 +298,7 @@ class PsmqttApp:
             return 5
 
         if log_period_sec > 0:
-            self.status_topic = app.mqtt_client.topic_prefix + "psmqtt_status"
-            logging.info(f"PSMQTT status will be published on topic {self.status_topic} every {log_period_sec}sec")
-
+            logging.info(f"PSMQTT status will be published on topic {self.mqtt_client.get_psmqtt_status_topic()} every {log_period_sec}sec")
             self.scheduler.enter(log_period_sec, 1, PsmqttApp.on_log_timer, tuple([self]))
         #else: logging of the status has been disabled
 


### PR DESCRIPTION
This PR is enhancing observability of PSMQTT itself: now PSMQTT publishes a retained message any time it connects or disconnects to MQTT, so that its status (online/offline) can always be inspected via MQTT.
Also adds docs about PSMQTT observability.