### PR TITLE
Add a new "caller_task_id" to all handle() functions

### DIFF
--- a/src/handlers_base.py
+++ b/src/handlers_base.py
@@ -46,6 +46,17 @@ class BaseHandler:
         return
 
     def handle(self, params: list[str], caller_task_id: str) -> Payload:
+        '''
+        The handle() function is the core function of an handler:
+        it typically performs 3 steps in sequence:
+        1. validation of the input parameters
+        2. invoke the psutil/pySMART function via get_value() accessor function
+        3. filter of the output and conversion to "Payload" type
+
+        The 'caller_task_id' is a string that identifies the task that is invoking this handler.
+        This is useful only to stateful handlers, which need to store a state that is different
+        from task to task.
+        '''
         assert isinstance(params, list)
         raise Exception("Not implemented")
 

--- a/src/handlers_base.py
+++ b/src/handlers_base.py
@@ -45,7 +45,7 @@ class BaseHandler:
         self.name = name
         return
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
         raise Exception("Not implemented")
 
@@ -88,12 +88,12 @@ class ValueCommandHandler(MethodCommandHandler):
     This is a good class to be used when no parameters are expected.
     '''
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         '''
         Will call self.get_value()
         '''
         assert isinstance(params, list)
-        if params != []:
+        if len(params) > 0:
             raise Exception(f"{self.name}: Parameter '{params}' is not supported")
 
         return self.get_value()
@@ -103,7 +103,7 @@ class IndexCommandHandler(MethodCommandHandler):
     IndexCommandHandler handles psutil functions that return a list, e.g. the psutil.pids() function.
     '''
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         arr = self.get_value()
@@ -130,7 +130,7 @@ class TupleCommandHandler(MethodCommandHandler):
     tuple, e.g. psutil.cpu_times, psutil.cpu_stats, psutil.virtual_memory, psutil.swap_memory
     '''
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         tup = self.get_value()
@@ -163,7 +163,7 @@ class IndexTupleCommandHandler(MethodCommandHandler):
     list of named tuples, e.g. psutil.disk_partitions, psutil.users
     '''
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         '''
         This handler accepts 1 or 2 parameters.
         The first parameter shall be:
@@ -230,7 +230,7 @@ class IndexOrTotalCommandHandler(BaseHandler):
         super().__init__(name)
         return
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         total = True
@@ -296,7 +296,7 @@ class IndexOrTotalTupleCommandHandler(MethodCommandHandler):
     def __init__(self, name:str):
         super().__init__(name)
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         if len(params) != 1 and len(params) != 2:
@@ -369,7 +369,7 @@ class NameOrTotalTupleCommandHandler(MethodCommandHandler):
     or a dictionary of named tuples.
     '''
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         if len(params) != 1 and len(params) != 2:

--- a/src/handlers_base_test.py
+++ b/src/handlers_base_test.py
@@ -15,52 +15,56 @@ from .handlers_base import (
     ValueCommandHandler,
 )
 
+fake_task_id = "0.0"
+
 @pytest.mark.unit
 class TestHandlers(unittest.TestCase):
 
-    def test_value_command_handler(self) -> None:
+    def test_MockedValueCommandHandler(self) -> None:
         handler = type(
             "TestHandler",
             (ValueCommandHandler, object),
             {"get_value": lambda s: 50})('test')
         # normal execution
-        self.assertEqual(50, handler.handle([]))
-        # exceptions
-        self.assertRaises(Exception, handler.handle, ['a'])
-        self.assertRaises(Exception, handler.handle, ['/'])
-        self.assertRaises(Exception, handler.handle, ['*'])
+        self.assertEqual(50, handler.handle([], fake_task_id))
+        # exceptions: ValueCommandHandler does not accept any parameters
+        self.assertRaises(Exception, handler.handle, ['a'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*'], fake_task_id)
 
     def test_ValueCommandHandler(self) -> None:
         handler = ValueCommandHandler("cpu_percent")
         # normal execution
-        val = handler.handle([])
+        val = handler.handle([], fake_task_id)
         self.assertIsInstance(val, float)
-        # exceptions
-        self.assertRaises(Exception, handler.handle, ['a'])
+        # exceptions: ValueCommandHandler does not accept any parameters
+        self.assertRaises(Exception, handler.handle, ['a'], fake_task_id)
 
         return
 
-    def test_index_command_handler(self) -> None:
+    def test_MockedIndexCommandHandler(self) -> None:
         handler = type(
             "TestHandler",
             (IndexCommandHandler, object),
             {"get_value": lambda s: [5, 6, 7]})('test')
         # normal execution
-        self.assertEqual(5, handler.handle(['0']))
-        self.assertEqual([5, 6, 7], handler.handle(['*']))
-        self.assertEqual("[5, 6, 7]", handler.handle(['+']))
-        self.assertEqual(3, handler.handle(['count']))
+        self.assertEqual(5, handler.handle(['0'], fake_task_id))
+        self.assertEqual(6, handler.handle(['1'], fake_task_id))
+        self.assertEqual(7, handler.handle(['2'], fake_task_id))
+        self.assertEqual([5, 6, 7], handler.handle(['*'], fake_task_id))
+        self.assertEqual("[5, 6, 7]", handler.handle(['+'], fake_task_id))
+        self.assertEqual(3, handler.handle(['count'], fake_task_id))
 
-        # exceptions
-        self.assertRaises(Exception, handler.handle, [''])
-        self.assertRaises(Exception, handler.handle, ['3'])
-        self.assertRaises(Exception, handler.handle, ['/'])
-        self.assertRaises(Exception, handler.handle, ['*/'])
-        self.assertRaises(Exception, handler.handle, ['/*'])
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
+        # exceptions: IndexCommandHandler wants a single parameter of type int (or string that can be converted to int)
+        self.assertRaises(Exception, handler.handle, [''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['3'], fake_task_id)  # 3 is outside range
+        self.assertRaises(Exception, handler.handle, ['/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['/*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
         return
 
     def test_IndexCommandHandler(self) -> None:
@@ -69,37 +73,38 @@ class TestHandlers(unittest.TestCase):
         psutil_val = handler.get_value()
         self.assertIsInstance(psutil_val, list)
 
-        val1 = handler.handle(['*'])
+        val1 = handler.handle(['*'], fake_task_id)
         self.assertIsInstance(val1, list)
 
-        val2 = handler.handle(['count'])
+        val2 = handler.handle(['count'], fake_task_id)
         assert isinstance(psutil_val, list)
         self.assertEqual(val2, len(psutil_val))
 
-        val3 = handler.handle(['1'])
+        val3 = handler.handle(['1'], fake_task_id)
         self.assertEqual(val3, psutil_val[1])
         return
 
-    def test_tuple_command_handler(self) -> None:
-        test = namedtuple('test', 'a b')
+    def test_MockedTupleCommandHandler(self) -> None:
+        testTuple = namedtuple('test', 'a b')
         handler = type(
             "TestHandler",
             (TupleCommandHandler, object),
             {
-                "get_value": lambda s: test(10, 20)
+                "get_value": lambda s: testTuple(10, 20)
             })('test')
         # normal execution
-        self.assertEqual(10, handler.handle(['a']))
-        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*']))
-        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+']))
-        # exceptions
-        self.assertRaises(Exception, handler.handle, [])
-        self.assertRaises(Exception, handler.handle, [''])
-        self.assertRaises(Exception, handler.handle, ['', '*'])
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
+        self.assertEqual(10, handler.handle(['a'], fake_task_id))
+        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*'], fake_task_id))
+        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+'], fake_task_id))
+        # exceptions: TupleCommandHandler wants a single parameter of type string representing the name
+        # of one of the fields of the namedtuple returned by get_value()
+        self.assertRaises(Exception, handler.handle, [], fake_task_id)
+        self.assertRaises(Exception, handler.handle, [''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', '*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
 
     def test_TupleCommandHandler(self) -> None:
         for foo in ('cpu_times', 'cpu_stats', 'virtual_memory', 'swap_memory'):
@@ -120,84 +125,85 @@ class TestHandlers(unittest.TestCase):
                 self.assertIsInstance(val, tuple)
         return
 
-    def test_index_tuple_command_handler(self) -> None:
+    def test_MockedIndexTupleCommandHandler(self) -> None:
         test = namedtuple('test', 'a b')
-        r = [
+        listOfTestTuples = [
             test(1, 2),
             test(3, 4)
         ]
         handler = type(
             "TestHandler",
             (IndexTupleCommandHandler, object),
-            {"get_value": lambda s: r})('test')
+            {"get_value": lambda s: listOfTestTuples})('test')
         # normal execution
-        self.assertEqual([1, 3], handler.handle(['a', '*']))
-        self.assertEqual("[1, 3]", handler.handle(['a', '+']))
-        self.assertEqual(3, handler.handle(['a', '1']))
-        self.assertEqual({'a': 3, 'b': 4}, handler.handle(['*', '1']))
-        self.assertEqual('{"a": 3, "b": 4}', handler.handle(['+', '1']))
-        # exceptions
-        self.assertRaises(Exception, handler.handle, [''])
-        self.assertRaises(Exception, handler.handle, ['*'])
-        self.assertRaises(Exception, handler.handle, ['+'])
-        self.assertRaises(Exception, handler.handle, ['a'])
-        self.assertRaises(Exception, handler.handle, ['a', ''])
-        self.assertRaises(Exception, handler.handle, ['*', ''])
-        self.assertRaises(Exception, handler.handle, ['', '*'])
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
+        self.assertEqual([1, 3], handler.handle(['a', '*'], fake_task_id))
+        self.assertEqual("[1, 3]", handler.handle(['a', '+'], fake_task_id))
+        self.assertEqual(3, handler.handle(['a', '1'], fake_task_id))
+        self.assertEqual({'a': 3, 'b': 4}, handler.handle(['*', '1'], fake_task_id))
+        self.assertEqual('{"a": 3, "b": 4}', handler.handle(['+', '1'], fake_task_id))
+        # exceptions: IndexTupleCommandHandler wants as first parameter a valid field name of the namedtuple
+        # and as second parameter a valid index within the list of tuples returned by get_value()
+        self.assertRaises(Exception, handler.handle, [''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['+'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['a'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['a', ''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*', ''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', '*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
 
-    def test_index_or_total_command_handler(self) -> None:
+    def test_MockedIndexOrTotalCommandHandler(self) -> None:
         handler = type("TestHandler", (IndexOrTotalCommandHandler, object),
-                       {"get_value": lambda s, t: 5 if t else [1, 2, 3]})('test')
+                       {"get_value": lambda s, total: 5 if total else [1, 2, 3]})('test')
         # normal execution
-        self.assertEqual(5, handler.handle(['']))
-        self.assertEqual(1, handler.handle(['0']))
-        self.assertEqual(3, handler.handle(['2']))
-        self.assertEqual([1, 2, 3], handler.handle(['*']))
-        self.assertEqual("[1, 2, 3]", handler.handle(['+']))
-        self.assertEqual(3, handler.handle(['count']))
+        self.assertEqual(5, handler.handle([''], fake_task_id))
+        self.assertEqual(1, handler.handle(['0'], fake_task_id))
+        self.assertEqual(3, handler.handle(['2'], fake_task_id))
+        self.assertEqual([1, 2, 3], handler.handle(['*'], fake_task_id))
+        self.assertEqual("[1, 2, 3]", handler.handle(['+'], fake_task_id))
+        self.assertEqual(3, handler.handle(['count'], fake_task_id))
         # exceptions
-        self.assertRaises(Exception, handler.handle, ['*-'])
-        self.assertRaises(Exception, handler.handle, ['*', ''])
-        self.assertRaises(Exception, handler.handle, ['', '*'])
+        self.assertRaises(Exception, handler.handle, ['*-'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*', ''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', '*'], fake_task_id)
         self.assertRaises(Exception, handler.handle, '3')
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
 
-    def test_index_or_total_tuple_command_handler(self) -> None:
-        test = namedtuple('test', 'a b')
-        total = test(10, 20)
-        single = [test(1, 2), test(3, 4)]
+    def test_MockedIndexOrTotalTupleCommandHandler(self) -> None:
+        testTuple = namedtuple('test', 'a b')
+        totalTuple = testTuple(10, 20)
+        listTuple = [testTuple(1, 2), testTuple(3, 4)]
         handler = type("TestHandler", (IndexOrTotalTupleCommandHandler, object),
-                       {"get_value": lambda s, t: total if t else single})('test')
+                       {"get_value": lambda s, total: totalTuple if total else listTuple})('test')
         # normal execution
-        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*']))
-        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+']))
-        self.assertEqual(10, handler.handle(['a']))
-        self.assertEqual([1, 3], handler.handle(['a', '*']))
-        self.assertEqual("[1, 3]", handler.handle(['a','+']))
-        self.assertEqual(3, handler.handle(['a','1']))
-        self.assertEqual({'a': 3, 'b': 4}, handler.handle(['*','1']))
-        self.assertEqual('{"a": 3, "b": 4}', handler.handle(['+','1']))
+        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*'], fake_task_id))
+        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+'], fake_task_id))
+        self.assertEqual(10, handler.handle(['a'], fake_task_id))
+        self.assertEqual([1, 3], handler.handle(['a', '*'], fake_task_id))
+        self.assertEqual("[1, 3]", handler.handle(['a','+'], fake_task_id))
+        self.assertEqual(3, handler.handle(['a','1'], fake_task_id))
+        self.assertEqual({'a': 3, 'b': 4}, handler.handle(['*','1'], fake_task_id))
+        self.assertEqual('{"a": 3, "b": 4}', handler.handle(['+','1'], fake_task_id))
         # exceptions
         #self.assertRaisesRegex(Exception, "Element '' in '' is not supported", handler.handle, '')
-        self.assertRaisesRegex(Exception, "Cannot list all elements and parameters at the same.*", handler.handle, ['*','*'])
-        self.assertRaises(Exception, handler.handle, ['*-'])
-        self.assertRaises(Exception, handler.handle, ['','*'])
-        self.assertRaises(Exception, handler.handle, ['3'])
-        self.assertRaises(Exception, handler.handle, ['','3'])
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['*','5'])
+        self.assertRaisesRegex(Exception, "Cannot list all elements and parameters at the same.*", handler.handle, ['*','*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*-'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['','*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['3'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['','3'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*','5'], fake_task_id)
 
-    def test_name_or_total_tuple_command_handler(self) -> None:
+    def test_MockedNameOrTotalTupleCommandHandler(self) -> None:
         test = namedtuple('test', 'a b')
         total = test(10, 20)
         single = {
@@ -209,25 +215,25 @@ class TestHandlers(unittest.TestCase):
             (NameOrTotalTupleCommandHandler, object),
             {"get_value": lambda s, t: total if t else single})('test')
         # normal execution
-        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*']))
-        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+']))
-        self.assertEqual(10, handler.handle(['a']))
-        self.assertEqual({"x": 1, "y": 3}, handler.handle(['a','*']))
-        self.assertEqual('{"x": 1, "y": 3}', handler.handle(['a','+']))
-        self.assertEqual(3, handler.handle(['a','y']))
-        self.assertEqual({'a': 3, 'b': 4}, handler.handle(['*','y']))
-        self.assertEqual('{"a": 3, "b": 4}', handler.handle(['+','y']))
+        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*'], fake_task_id))
+        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+'], fake_task_id))
+        self.assertEqual(10, handler.handle(['a'], fake_task_id))
+        self.assertEqual({"x": 1, "y": 3}, handler.handle(['a','*'], fake_task_id))
+        self.assertEqual('{"x": 1, "y": 3}', handler.handle(['a','+'], fake_task_id))
+        self.assertEqual(3, handler.handle(['a','y'], fake_task_id))
+        self.assertEqual({'a': 3, 'b': 4}, handler.handle(['*','y'], fake_task_id))
+        self.assertEqual('{"a": 3, "b": 4}', handler.handle(['+','y'], fake_task_id))
         # exceptions
-        self.assertRaisesRegex(Exception, "Element '' in .* is not supported", handler.handle, [''])
-        self.assertRaisesRegex(Exception, "Cannot list all elements and parameters at the same.*", handler.handle, ['*','*'])
-        self.assertRaises(Exception, handler.handle, ['*-'])
-        self.assertRaises(Exception, handler.handle, ['','*'])
-        self.assertRaises(Exception, handler.handle, ['3'])
-        self.assertRaises(Exception, handler.handle, ['','3'])
-        self.assertRaises(Exception, handler.handle, ['a','0'])
-        self.assertRaises(Exception, handler.handle, ['c','x'])
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['*','5'])
+        self.assertRaisesRegex(Exception, "Element '' in .* is not supported", handler.handle, [''], fake_task_id)
+        self.assertRaisesRegex(Exception, "Cannot list all elements and parameters at the same.*", handler.handle, ['*','*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*-'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['','*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['3'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['','3'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['a','0'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['c','x'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*','5'], fake_task_id)

--- a/src/handlers_psutil.py
+++ b/src/handlers_psutil.py
@@ -18,7 +18,7 @@ class DiskCountersIOCommandHandler(MethodCommandHandler):
     def __init__(self):
         super().__init__('disk_io_counters')
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         if len(params) != 1 and len(params) != 2:
@@ -93,7 +93,7 @@ class DiskUsageCommandHandler(MethodCommandHandler):
         super().__init__('disk_usage')
         return
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         if len(params) != 2:
@@ -128,7 +128,7 @@ class SensorsTemperaturesCommandHandler(MethodCommandHandler):
         super().__init__('sensors_temperatures')
         return
 
-    def handle(self, params: list[str]) -> Payload:
+    def handle(self, params: list[str], caller_task_id: str) -> Payload:
         '''
         '''
         assert isinstance(params, list)
@@ -180,7 +180,7 @@ class SensorsFansCommandHandler(MethodCommandHandler):
         super().__init__('sensors_fans')
         return
 
-    def handle(self, params:list[str]) -> Payload:
+    def handle(self, params:list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         if len(params) < 1 or len(params) > 3:

--- a/src/handlers_psutil_processes.py
+++ b/src/handlers_psutil_processes.py
@@ -18,6 +18,12 @@ from .handlers_base import TaskParam
 
 class ProcessesCommandHandler(BaseHandler):
     '''
+    This is the handler linking the Task class to the family of the
+    ProcessCommandHandler-derived classes.
+    This class is in charge of using psutil.process_iter() function
+     (https://psutil.readthedocs.io/en/latest/#psutil.process_iter)
+    to iterate over all running processes and extract the information
+    selected via the usual parameters provided to the handle() method.
     '''
 
     top_cpu_regexp = re.compile(r"^top_cpu(\[\d+\])*$")
@@ -30,7 +36,7 @@ class ProcessesCommandHandler(BaseHandler):
         super().__init__('processes')
         return
 
-    def handle(self, params:list[str]) -> Payload:
+    def handle(self, params:list[str], caller_task_id: str) -> Payload:
         assert isinstance(params, list)
 
         if len(params) != 2 and len(params) != 3:
@@ -104,7 +110,7 @@ class ProcessesCommandHandler(BaseHandler):
 
 class ProcessCommandHandler:
     '''
-
+    Base abstract class for all process-related command handlers.
     '''
     def __init__(self, name:str):
         self.name = name
@@ -115,6 +121,11 @@ class ProcessCommandHandler:
 
 
 class ProcessMethodCommandHandler(ProcessCommandHandler):
+    '''
+    This class implements the get_value() function by applying the psutil.Process.<METHOD>
+    function to the process instance passed as a parameter to get_value(),
+    where <METHOD> is actually the name of the class instance.
+    '''
     def __init__(self, name:str):
         super().__init__(name)
         try:
@@ -197,7 +208,7 @@ class ProcessPropertiesCommandHandler(ProcessCommandHandler):
 
 class ProcessMethodIndexCommandHandler(ProcessMethodCommandHandler):
 
-    def handle(self, params: list[str],process:psutil.Process) -> Payload:
+    def handle(self, params: list[str], process:psutil.Process) -> Payload:
         assert isinstance(params, list)
         if len(params) != 1:
             raise Exception(f"Exactly 1 parameter is supported for '{self.name}'; found {len(params)} parameters instead: {params}")
@@ -220,7 +231,7 @@ class ProcessMethodIndexCommandHandler(ProcessMethodCommandHandler):
 
 class ProcessMethodTupleCommandHandler(ProcessMethodCommandHandler):
 
-    def handle(self, params: list[str],process:psutil.Process) -> Payload:
+    def handle(self, params: list[str], process:psutil.Process) -> Payload:
         assert isinstance(params, list)
         if len(params) != 1:
             raise Exception(f"Exactly 1 parameter is supported for '{self.name}'; found {len(params)} parameters instead: {params}")

--- a/src/handlers_psutil_processes_test.py
+++ b/src/handlers_psutil_processes_test.py
@@ -8,12 +8,14 @@ from .handlers_psutil_processes import (
     ProcessesCommandHandler
 )
 
+fake_task_id = "0.0"
+
 @pytest.mark.unit
 class TestHandlers(unittest.TestCase):
 
     def test_ProcessesCommandHandler(self) -> None:
         handler = ProcessesCommandHandler()
-        processes = handler.handle(['*','name'])
+        processes = handler.handle(['*','name'], fake_task_id)
         self.assertIsInstance(processes, dict)
         assert isinstance(processes, dict)
         self.assertGreater(len(processes), 3)
@@ -28,15 +30,15 @@ class TestHandlers(unittest.TestCase):
             assert isinstance(v, str)
             assert isinstance(k, int)
 
-        res = handler.handle([f'{last_pid}','name'])
+        res = handler.handle([f'{last_pid}','name'], fake_task_id)
         self.assertEqual(res, last_name)
 
-        processes = handler.handle(['top_cpu','name'])
+        processes = handler.handle(['top_cpu','name'], fake_task_id)
         self.assertIsInstance(processes, str)
 
-        processes = handler.handle(['top_memory','exe'])
+        processes = handler.handle(['top_memory','exe'], fake_task_id)
         self.assertIsInstance(processes, str)
 
-        pid = handler.handle([f'name[{last_name}]','pid'])
+        pid = handler.handle([f'name[{last_name}]','pid'], fake_task_id)
         self.assertEqual(pid, last_pid)
         return

--- a/src/handlers_psutil_test.py
+++ b/src/handlers_psutil_test.py
@@ -14,33 +14,35 @@ from .handlers_psutil import (
     SensorsFansCommandHandler
 )
 
+fake_task_id = "0.0"
+
 @pytest.mark.unit
 class TestHandlers(unittest.TestCase):
 
-    def test_disk_usage_command_handler(self) -> None:
+    def test_MockedDiskUsageCommandHandler(self) -> None:
         disk: Optional[str] = '/'
         handler = type("TestHandler", (DiskUsageCommandHandler, object),
                        {"get_value": lambda s,d: self._disk_usage_get_value(disk, d)})()
         # normal execution: read field "a" from the fake tuple returned for disk "/"
-        self.assertEqual(10, handler.handle(['a', '/']))
-        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*', '/']))
-        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+', '/']))
-        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+', '/']))
+        self.assertEqual(10, handler.handle(['a', '/'], fake_task_id))
+        self.assertEqual({'a': 10, 'b': 20}, handler.handle(['*', '/'], fake_task_id))
+        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+', '/'], fake_task_id))
+        self.assertEqual('{"a": 10, "b": 20}', handler.handle(['+', '/'], fake_task_id))
         disk = 'c:'
-        self.assertEqual(10, handler.handle(['a','c:']))
+        self.assertEqual(10, handler.handle(['a','c:'], fake_task_id))
         disk = 'c:/'
-        self.assertEqual(10, handler.handle(['a','c:/']))
+        self.assertEqual(10, handler.handle(['a','c:/'], fake_task_id))
         # exceptions
         disk = None     # do not validate disk, only parameters
-        self.assertRaises(Exception, handler.handle, ['a'])
-        self.assertRaises(Exception, handler.handle, ['a',''])
-        self.assertRaises(Exception, handler.handle, ['/'])
-        self.assertRaises(Exception, handler.handle, ['*',''])
-        self.assertRaises(Exception, handler.handle, ['','*'])
-        self.assertRaises(Exception, handler.handle, ['blabla'])
-        self.assertRaises(Exception, handler.handle, ['bla', 'bla'])
-        self.assertRaises(Exception, handler.handle, ['bla/'])
-        self.assertRaises(Exception, handler.handle, ['', 'bla'])
+        self.assertRaises(Exception, handler.handle, ['a'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['a',''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['*',''], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['','*'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['blabla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla', 'bla'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['bla/'], fake_task_id)
+        self.assertRaises(Exception, handler.handle, ['', 'bla'], fake_task_id)
 
     def _disk_usage_get_value(self, disk: Optional[str], d:str) -> NamedTuple:
         if disk is not None:
@@ -54,30 +56,30 @@ class TestHandlers(unittest.TestCase):
         self.assertIsInstance(val, tuple)
         return
 
-    def test_temperature_sensors(self) -> None:
+    def test_MockedSensorsTemperaturesCommandHandler(self) -> None:
         handler = type(
             "TestHandler",
             (SensorsTemperaturesCommandHandler, object),
             {
                 "get_value": lambda s: self._temperature_sensors_get_value()
             })()
-        self.assertEqual(handler.handle(['*']), {"asus": [30.0], "coretemp": [45.0, 52.0]})
-        self.assertEqual(handler.handle(['+']), '{"asus": [30.0], "coretemp": [45.0, 52.0]}')
-        self.assertEqual(handler.handle(['asus']), [30.0])
-        self.assertEqual(handler.handle(['asus','*']), [{"label": "", "current": 30.0, "high": None, "critical": None}])
-        self.assertEqual(handler.handle(['asus','+']), '[{"critical": null, "current": 30.0, "high": null, "label": ""}]')
-        self.assertEqual(handler.handle(['asus','','*']), {'label': '', 'current': 30.0, 'high': None, 'critical': None})
-        self.assertEqual(handler.handle(['asus','','+']), '{"critical": null, "current": 30.0, "high": null, "label": ""}')
-        self.assertEqual(handler.handle(['asus','','current']), 30.0)
-        self.assertEqual(handler.handle(['asus',0]), 30.0)
-        self.assertEqual(handler.handle(['asus',0,'*']), {'label': '', 'current': 30.0, 'high': None, 'critical': None})
-        self.assertEqual(handler.handle(['asus',0,'+']), '{"critical": null, "current": 30.0, "high": null, "label": ""}')
-        self.assertEqual(handler.handle(['asus',0,'current']), 30.0)
-        self.assertEqual(handler.handle(['coretemp']), [45.0, 52.0])
-        self.assertEqual(handler.handle(['coretemp','Core 0']), 45.0)
-        self.assertEqual(handler.handle(['coretemp','Core 0','*']), {'label': 'Core 0', 'current': 45.0, 'high': 100.0, 'critical': 100.0})
-        self.assertEqual(handler.handle(['coretemp','Core 0','+']), '{"critical": 100.0, "current": 45.0, "high": 100.0, "label": "Core 0"}')
-        self.assertEqual(handler.handle(['coretemp','Core 0','current']), 45.0)
+        self.assertEqual(handler.handle(['*'], fake_task_id), {"asus": [30.0], "coretemp": [45.0, 52.0]})
+        self.assertEqual(handler.handle(['+'], fake_task_id), '{"asus": [30.0], "coretemp": [45.0, 52.0]}')
+        self.assertEqual(handler.handle(['asus'], fake_task_id), [30.0])
+        self.assertEqual(handler.handle(['asus','*'], fake_task_id), [{"label": "", "current": 30.0, "high": None, "critical": None}])
+        self.assertEqual(handler.handle(['asus','+'], fake_task_id), '[{"critical": null, "current": 30.0, "high": null, "label": ""}]')
+        self.assertEqual(handler.handle(['asus','','*'], fake_task_id), {'label': '', 'current': 30.0, 'high': None, 'critical': None})
+        self.assertEqual(handler.handle(['asus','','+'], fake_task_id), '{"critical": null, "current": 30.0, "high": null, "label": ""}')
+        self.assertEqual(handler.handle(['asus','','current'], fake_task_id), 30.0)
+        self.assertEqual(handler.handle(['asus',0], fake_task_id), 30.0)
+        self.assertEqual(handler.handle(['asus',0,'*'], fake_task_id), {'label': '', 'current': 30.0, 'high': None, 'critical': None})
+        self.assertEqual(handler.handle(['asus',0,'+'], fake_task_id), '{"critical": null, "current": 30.0, "high": null, "label": ""}')
+        self.assertEqual(handler.handle(['asus',0,'current'], fake_task_id), 30.0)
+        self.assertEqual(handler.handle(['coretemp'], fake_task_id), [45.0, 52.0])
+        self.assertEqual(handler.handle(['coretemp','Core 0'], fake_task_id), 45.0)
+        self.assertEqual(handler.handle(['coretemp','Core 0','*'], fake_task_id), {'label': 'Core 0', 'current': 45.0, 'high': 100.0, 'critical': 100.0})
+        self.assertEqual(handler.handle(['coretemp','Core 0','+'], fake_task_id), '{"critical": 100.0, "current": 45.0, "high": 100.0, "label": "Core 0"}')
+        self.assertEqual(handler.handle(['coretemp','Core 0','current'], fake_task_id), 45.0)
 
     @staticmethod
     def _temperature_sensors_get_value() -> Dict[str, Any]:

--- a/src/handlers_pysmart.py
+++ b/src/handlers_pysmart.py
@@ -19,7 +19,7 @@ class SmartCommandHandler(BaseHandler):
         super().__init__('smart')
         return
 
-    def handle(self, params: List[str]) -> Payload:
+    def handle(self, params: List[str], caller_task_id: str) -> Payload:
         '''
         Takes 2 parameters:
         * device name

--- a/src/handlers_pysmart_test.py
+++ b/src/handlers_pysmart_test.py
@@ -8,6 +8,8 @@ from .handlers_pysmart import (
     SmartCommandHandler,
 )
 
+fake_task_id = "0.0"
+
 @pytest.mark.unit
 class TestHandlers(unittest.TestCase):
 
@@ -15,7 +17,7 @@ class TestHandlers(unittest.TestCase):
         handler = SmartCommandHandler()
         #val = handler.get_value()
         try:
-            val = handler.handle('dev/nvme0')
+            val = handler.handle(['dev/nvme0'], fake_task_id)
             #print(val)
             self.assertIsInstance(val, dict)
             assert isinstance(val, dict)
@@ -23,6 +25,7 @@ class TestHandlers(unittest.TestCase):
             self.assertEqual(
                 handler.handle('*'), {"asus": [30.0], "coretemp": [45.0, 52.0]})
         except Exception:
+            # test must be ignored if no SMART devices are available
             pass
 
         return


### PR DESCRIPTION
This PR is paving the way for stateful task handlers by adding a new "caller_task_id" parameter to all handle() functions.
The 'caller_task_id' is a string that identifies the task that is invoking this handler.
This is useful only to stateful handlers, which need to store a state that is different from task to task.

This PR is also removing the copy-pasted 'process_handlers' dict from task.py since the truly-used dict is declared inside handlers_psutil_processes.py