### PR TITLE
Add new GetLoadAvgCommandHandler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,8 @@ jobs:
           multiPlatform: true
           platform: linux/amd64,linux/arm64,linux/arm/v7
           image: psmqtt
+          tags: ${{ steps.meta.outputs.version }}
+          addLatest: false
           # options related to PUSHing the docker image:
           registry: ghcr.io
           pushImage: false
@@ -113,8 +115,21 @@ jobs:
       - name: Metadata extraction
         id: meta
         uses: docker/metadata-action@v5
+      - name: Decorate docker image version
+        id: docker_version
+        run: |
+          ver=${{ steps.meta.outputs.version }}
+          # Add the 'latest' tag only to tag builds
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "version=$ver,latest" >> $GITHUB_OUTPUT
+          else
+            #if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            #  echo "version=$ver,latest" >> $GITHUB_OUTPUT
+            #fi
+            echo "version=$ver" >> $GITHUB_OUTPUT
+          fi
       - run: |
-          echo "Docker image will be versioned as: ${{ steps.meta.outputs.version }}"
+          echo "Docker image will be versioned as: ${{ steps.docker_version.outputs.version }}"
 
       - name: Build and push Docker image [non-root]
         uses: mr-smithers-excellent/docker-build-push@v6
@@ -124,7 +139,7 @@ jobs:
           multiPlatform: true
           platform: linux/amd64,linux/arm64,linux/arm/v7
           image: psmqtt
-          tags: ${{ steps.meta.outputs.version }},latest
+          tags: ${{ steps.docker_version.outputs.version }}
           addLatest: false
           # options related to PUSHing the docker image:
           registry: ghcr.io
@@ -142,8 +157,21 @@ jobs:
       - name: Metadata extraction
         id: meta
         uses: docker/metadata-action@v5
+      - name: Decorate docker image version
+        id: docker_version
+        run: |
+          ver=${{ steps.meta.outputs.version }}
+          # Add the 'latest' tag only to tag builds
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "version=${ver}-root,latest-root" >> $GITHUB_OUTPUT
+          else
+            #if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            #  echo "version=$ver,latest" >> $GITHUB_OUTPUT
+            #fi
+            echo "version=${ver}-root" >> $GITHUB_OUTPUT
+          fi
       - run: |
-          echo "Docker image will be versioned as: ${{ steps.meta.outputs.version }}-root"
+          echo "Docker image will be versioned as: ${{ steps.docker_version.outputs.version }}"
 
       - name: Build and push Docker image [root]
         uses: mr-smithers-excellent/docker-build-push@v6
@@ -154,10 +182,11 @@ jobs:
           platform: linux/amd64,linux/arm64,linux/arm/v7
           image: psmqtt
           buildArgs: USERNAME=root
-          tags: ${{ steps.meta.outputs.version }}-root,latest-root
+          tags: ${{ steps.docker_version.outputs.version }}
           addLatest: false
           # options related to PUSHing the docker image:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.PAT_TOKEN_FOR_GITHUB }}
           pushImage: true
+

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -221,7 +221,8 @@ Here follows the reference documentation for all required tasks and their parame
   * Task name: `getloadavg`
     * Short description: Average system load in last 1, 5 and 15 minutes. [ Full reference ]( https://psutil.readthedocs.io/en/latest/#psutil.getloadavg )
     * **REQUIRED**: `<param1>`: The wildcard `*`  or `+` to select all 3 available values (`last1min`, `last5min`, `last15min`) or a field name like `last1min`, `last5min`, `last15min` (single-valued task).
-    * **OPTIONAL**: `<param2>`: The string `percent` to produce the system CPU load as a percentage (where 100% indicates full utilization of all available CPU cores) or `absolute` to produce in output the plain system load number returned by psutil, which only make sense if related to the number of CPU cores installed on the system. 
+    * **OPTIONAL**: `<param2>`: The string `percent` to produce the system CPU load as a percentage (where 100% indicates full utilization of all available CPU cores) or `absolute` to produce in output the plain system load number returned by psutil, which only make sense if related to the number of CPU cores installed on the system.
+    The default value is `percent`.
 
 #### <a name='CategoryMemory'></a>Category Memory
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -217,7 +217,11 @@ Here follows the reference documentation for all required tasks and their parame
       Note that you cannot use a wildcard as `<param2>` together with a wildcard on `<param1>`.
   * Task name: `cpu_stats`
     * Short description: CPU statistics. [ Full reference ]( https://psutil.readthedocs.io/en/latest/#psutil.cpu_stats )
-    * **REQUIRED**: `<param1>`: The wildcard `*`  or `+` to select all fields (multi-valued task) or or a field name like `ctx_switches`, `interrupts`, `soft_interrupts`, `syscalls` (single-valued task).
+    * **REQUIRED**: `<param1>`: The wildcard `*`  or `+` to select all fields (multi-valued task) or a field name like `ctx_switches`, `interrupts`, `soft_interrupts`, `syscalls` (single-valued task).
+  * Task name: `getloadavg`
+    * Short description: Average system load in last 1, 5 and 15 minutes. [ Full reference ]( https://psutil.readthedocs.io/en/latest/#psutil.getloadavg )
+    * **REQUIRED**: `<param1>`: The wildcard `*`  or `+` to select all 3 available values (`last1min`, `last5min`, `last15min`) or a field name like `last1min`, `last5min`, `last15min` (single-valued task).
+    * **OPTIONAL**: `<param2>`: The string `percent` to produce the system CPU load as a percentage (where 100% indicates full utilization of all available CPU cores) or `absolute` to produce in output the plain system load number returned by psutil, which only make sense if related to the number of CPU cores installed on the system. 
 
 #### <a name='CategoryMemory'></a>Category Memory
 

--- a/psmqtt.yaml
+++ b/psmqtt.yaml
@@ -4,7 +4,7 @@
 #
 
 logging:
-  level: INFO
+  level: DEBUG
 
   # psmqtt will report its own status (e.g. number of errors) every N seconds on its log output
   # and on the specific '<mqtt.publish_topic_prefix>/status' topic
@@ -201,6 +201,16 @@ schedule:
           payload_off: PASS
           device_class: problem
           icon: mdi:harddisk
+
+  - cron: "every 1 minutes"
+    tasks:
+      - task: getloadavg
+        params: [ "last5min", "percent" ]
+        ha_discovery:
+          name: "Average System Load"
+          platform: sensor
+          unit_of_measurement: "%"
+          icon: mdi:speedometer
 
   - cron: "every 60 minutes"
     tasks:

--- a/src/task.py
+++ b/src/task.py
@@ -15,7 +15,7 @@ from .formatter import Formatter
 
 from .handlers_base import Payload, TupleCommandHandler, ValueCommandHandler, IndexCommandHandler, IndexOrTotalCommandHandler, IndexTupleCommandHandler, IndexOrTotalTupleCommandHandler
 from .handlers_psutil_processes import ProcessesCommandHandler
-from .handlers_psutil import DiskIOCountersCommandHandler, DiskIOCountersRateHandler, DiskUsageCommandHandler, NetIOCountersCommandHandler, NetIOCountersRateHandler, SensorsFansCommandHandler, SensorsTemperaturesCommandHandler
+from .handlers_psutil import DiskIOCountersCommandHandler, DiskIOCountersRateHandler, DiskUsageCommandHandler, NetIOCountersCommandHandler, NetIOCountersRateHandler, SensorsFansCommandHandler, SensorsTemperaturesCommandHandler, GetLoadAvgCommandHandler
 from .handlers_pysmart import SmartCommandHandler
 
 class Task:
@@ -83,6 +83,8 @@ class Task:
         'processes': ProcessesCommandHandler(),
 
         # OTHERS
+
+        'getloadavg': GetLoadAvgCommandHandler(),
         'users': IndexTupleCommandHandler('users'),
         'boot_time': ValueCommandHandler('boot_time'),
         'pids': IndexCommandHandler('pids'),

--- a/src/task.py
+++ b/src/task.py
@@ -60,6 +60,8 @@ class Task:
 
         'cpu_stats': TupleCommandHandler('cpu_stats'),
 
+        'getloadavg': GetLoadAvgCommandHandler(),
+
         # MEMORY
 
         'virtual_memory': TupleCommandHandler('virtual_memory'),
@@ -84,7 +86,6 @@ class Task:
 
         # OTHERS
 
-        'getloadavg': GetLoadAvgCommandHandler(),
         'users': IndexTupleCommandHandler('users'),
         'boot_time': ValueCommandHandler('boot_time'),
         'pids': IndexCommandHandler('pids'),


### PR DESCRIPTION
This PR is addressing issue #89 by:
* adding a new GetLoadAvgCommandHandler to handle the output of psutil.getloadavg() sensor
* adds docs for the new Task handler

Unrelated: this PR also contains a CI pipeline fix to properly overwrite the "latest" and "latest-root" docker image tags only when building tags (= released versions of psmqtt)

TODO: unit tests