### PR TITLE
Fix psmqtt wheel which was missing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ test-wheel:
 		$(MAKE) build-wheel && \
 		pip3 install dist/psmqtt-*-py3-none-any.whl
 
+inspect-wheel:
+	# see https://github.com/wheelodex/wheel-inspect
+	wheel2json dist/psmqtt-*-py3-none-any.whl
+
 test: unit-test integration-test
 
 unit-test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,11 @@ dependencies = {file = ["requirements.txt"]}
 psmqtt = "psmqtt:main.main"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]
 
 [tool.hatch.build.targets.wheel]
 only-include = ["src"]


### PR DESCRIPTION
This PR is fixing the Python wheel which was missing the list of dependencies. Thus prior to this bugfix the "pip install psmqtt" command was installing psmqtt without its dependencies